### PR TITLE
Automatically find common ancestor for two topic branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Usage:
 to compare the topic branch represented by the range A..B with that in
 the range C..D.
 
+or:
+
+    git tbdiff A...B
+
+to let tbdiff automatically calculate the common ancestor X and
+compare the range X..A to X..B.
 
 ### Synopsis
 
@@ -26,6 +32,9 @@ the range C..D.
                [--creation-weight=<factor>]
                <range1> <range2>
 
+    git tbdiff [--[no-]color] [--no-patches]
+               [--creation-weight=<factor>]
+               <committish1>...<committish2>
 
 ### Description
 


### PR DESCRIPTION
Often two versions of a topic branch start at a common ancestor, or only
the changes from the first common commit are interesting.  Allow this
base commit to be found automatically, instead of having the user find
it every time tbdiff is used.
