### PR TITLE
README: mention the need for the `hungarian` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ If your system does not yet have a `/usr/bin/python2` symlink (older
 systems would only have `/usr/bin/python`), you will need to edit the
 `#!` line.
 
+You also need to make sure that the `hungarian` Python module is
+available, e.g. by running `pip install hungarian`.
+
 Usage:
 
     git tbdiff A..B C..D


### PR DESCRIPTION
It is easy for Python experts to know what to do about this error:

```
ImportError: No module named hungarian
```

Everybody else will appreciate a little help. So let's give it.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
