### PR TITLE
Pass --no-decorate to git-log

### DIFF
--- a/git-tbdiff.py
+++ b/git-tbdiff.py
@@ -75,7 +75,7 @@ def read_patches(rev_list_args):
     series = []
     diffs = {}
     p = subprocess.Popen(['git', 'log', '--no-color', '-p', '--no-merges',
-                          '--reverse', '--date-order']
+                          '--no-decorate', '--reverse', '--date-order']
                          + rev_list_args,
                          stdout=subprocess.PIPE)
     sha1 = None


### PR DESCRIPTION
Without this, parsing of the 'commit ' lines fails if you have log.decorate
set in your git config.
