### PR TITLE
Turn off log.decorate when parsing log output

### DIFF
--- a/git-tbdiff.py
+++ b/git-tbdiff.py
@@ -75,7 +75,8 @@ def read_patches(rev_list_args):
     series = []
     diffs = {}
     p = subprocess.Popen(['git', 'log', '--no-color', '-p', '--no-merges',
-                          '--reverse', '--date-order']
+                          '--reverse', '--date-order',
+                          '--decorate=no', '--no-abbrev-commit']
                          + rev_list_args,
                          stdout=subprocess.PIPE)
     sha1 = None


### PR DESCRIPTION
Given lines like:

    commit 0245492ee0
    commit 5b0af9d6f8 (sahildua/add-copy-branch-feature)

This code would error out with:

    Traceback (most recent call last):
      File "/home/avar/bin/git-tbdiff", line 400, in <module>
        sA, dA = read_patches(rangeA)
      File "/home/avar/bin/git-tbdiff", line 92, in read_patches
        _, sha1 = line.strip().split()
    ValueError: too many values to unpack

Fix that by turning off decorate for the log invocation, and while I'm
at it turn off commit abbreviation which isn't needed here either.